### PR TITLE
[feature] allowing wildcard lookups

### DIFF
--- a/cmd/examples/filetest.json
+++ b/cmd/examples/filetest.json
@@ -15,4 +15,9 @@
 }, {
   "path": "../cmd/root_test.go",
   "absent": true
+},{
+  "path": "../cmd/error*.go",
+  "contains": [
+    "package cmd---"
+  ]
 }]

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -17,7 +17,7 @@ func Test_Run_with_Errors(t *testing.T) {
 	r := require.New(t)
 	err := Run("./examples")
 	r.NoError(err)
-	r.Len(errs, 5)
+	r.Len(errs, 6)
 
 	msgs := make([]string, len(errs))
 	for _, e := range errs {
@@ -29,4 +29,5 @@ func Test_Run_with_Errors(t *testing.T) {
 	r.Contains(msgs, "../cmd/file.go: does not contain 'i dont exist'")
 	r.Contains(msgs, "../cmd/file.go: should not contain 'File'")
 	r.Contains(msgs, "../cmd/root_test.go: should not be present")
+	r.Contains(msgs, "../cmd/errors.go: does not contain 'package cmd---'")
 }


### PR DESCRIPTION
This PR allows to use wildcards on the path, it uses `filepath.Glob` to find matching files and picks the first one to check the rules described.

cc: @markbates.

