### PR TITLE
[bugfix] stop the rest of the checks if absent is set to true.

### DIFF
--- a/cmd/examples/filetest.json
+++ b/cmd/examples/filetest.json
@@ -20,4 +20,8 @@
   "contains": [
     "package cmd---"
   ]
+},
+{
+  "path": "../cmd/root_nod.go",
+  "absent": true
 }]

--- a/cmd/file.go
+++ b/cmd/file.go
@@ -35,7 +35,11 @@ func (f File) Test() error {
 	}
 
 	if f.Absent {
-		return Add(errors.Errorf("%s: should not be present", f.Path))
+		if err == nil {
+			return Add(errors.Errorf("%s: should not be present", f.Path))
+		}
+
+		return nil
 	}
 
 	b, err := ioutil.ReadFile(f.Path)


### PR DESCRIPTION
This one will stop checking for the rest of the rules if absent is set to true for a file.

@markbates sorry about all the issues on this feature, this one will cover a case i did not cover initially, sorry again.